### PR TITLE
Make the torch dependencies optional

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2572,14 +2572,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "portalocker"
-version = "2.6.0"
+version = "2.7.0"
 description = "Wraps the portalocker recipe for easy usage"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "portalocker-2.6.0-py2.py3-none-any.whl", hash = "sha256:102ed1f2badd8dec9af3d732ef70e94b215b85ba45a8d7ff3c0003f19b442f4e"},
-    {file = "portalocker-2.6.0.tar.gz", hash = "sha256:964f6830fb42a74b5d32bce99ed37d8308c1d7d44ddf18f3dd89f4680de97b39"},
+    {file = "portalocker-2.7.0-py2.py3-none-any.whl", hash = "sha256:a07c5b4f3985c3cf4798369631fb7011adb498e2a46d8440efc75a8f29a0f983"},
+    {file = "portalocker-2.7.0.tar.gz", hash = "sha256:032e81d534a88ec1736d03f780ba073f047a06c478b06e2937486f334e955c51"},
 ]
 
 [package.dependencies]
@@ -2588,7 +2588,7 @@ pywin32 = {version = ">=226", markers = "platform_system == \"Windows\""}
 [package.extras]
 docs = ["sphinx (>=1.7.1)"]
 redis = ["redis"]
-tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-timeout (>=2.1.0)", "redis", "sphinx (>=3.0.3)"]
+tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-timeout (>=2.1.0)", "redis", "sphinx (>=6.0.0)"]
 
 [[package]]
 name = "prometheus-client"
@@ -3049,7 +3049,7 @@ files = [
 name = "pywin32"
 version = "305"
 description = "Python for Window Extensions"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 files = [
@@ -3667,7 +3667,7 @@ opt-einsum = ["opt-einsum (>=3.3)"]
 name = "torchdata"
 version = "0.5.1"
 description = "Composable data loading modules for PyTorch"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -3719,7 +3719,7 @@ files = [
 name = "tqdm"
 version = "4.64.1"
 description = "Fast, Extensible Progress Meter"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 files = [
@@ -4105,7 +4105,10 @@ numpy = ">=1.7"
 [package.extras]
 jupyter = ["ipytree", "notebook"]
 
+[extras]
+torch = ["torch"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<3.12"
-content-hash = "0b179e91382980265a315d52492d09850acfdf90c4636eeb35b08c41be268023"
+content-hash = "f059d352ea88c692784d7753dda06f7bf3436b49cf6e36c214cd1774a6889a5d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ python = "^3.10,<3.12"
 scikit-learn = "^1.1.3,<1.2.0"
 pvlib = "^0.9.3"
 numpy = "^1.23.5"
-torch = "^1.13.1"
-torchdata = "^0.5.0"
 xarray = "^2022.12.0"
 click = "^8.1.3"
 google-cloud-storage = "^2.7.0"
@@ -24,6 +22,8 @@ h5netcdf = "^1.1.0"
 pyproj = "^3.4.1"
 fsspec = "^2022.11.0"
 gcsfs = "^2022.11.0"
+torch = {version="^1.13.1", optional=true}
+tqdm = "^4.64.1"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -37,7 +37,6 @@ isort = "^5.10.1"
 jupyter-contrib-nbextensions = "^0.7.0"
 black = {extras = ["jupyter"], version = "^22.10.0"}
 scipy = "^1.9.3"
-tqdm = "^4.64.1"
 pandas-stubs = "^1.5.2.221213"
 types-tqdm = "^4.64.7.9"
 mypy = "^0.991"
@@ -45,6 +44,11 @@ pyarrow = "^10.0.1"
 types-pyyaml = "^6.0.12.2"
 pylint = "^2.15.9"
 pydocstyle = "^6.2.3"
+torchdata = "^0.5.1"
+
+[tool.poetry.extras]
+torch = ["torch"]
+
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Those are the heaviest and are not always needed in prod.

* Make `torch` an "extra" dependencies. This means we need to do `pip install pv-site-prediction[torch] if we want to install it.
* Make `torchdata` a "dev" dependency. This means it's not part of what is installed when a third party does `pip install pv-site-prediction`.
