### PR TITLE
Use saved config

### DIFF
--- a/notebooks/experiment_analysis.ipynb
+++ b/notebooks/experiment_analysis.ipynb
@@ -84,18 +84,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1dfe7510",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXP_NAMES = [\"island-v3\"]\n",
+    "\n",
+    "REMOVE_WEIRD_PV_IDS = False\n",
+    "\n",
+    "ROUND_HORIZON_TO = 4\n",
+    "ROUND_PRED_TO = 30\n",
+    "WIDTH = 120"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "05e92615",
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "ROUND_HORIZON_TO = 4\n",
-    "ROUND_PRED_TO = 30\n",
-    "WIDTH = 120\n",
-    "REMOVE_WEIRD_PV_IDS = True\n",
-    "\n",
-    "\n",
     "def load_models(names):\n",
     "    dfs = []\n",
     "    for name in names:\n",
@@ -203,20 +213,10 @@
     "            width=30,\n",
     "        )\n",
     "    )\n",
-    "    return chart, chart2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0a789b73",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# names = [p.stem for p in pathlib.Path(\"exp_results\").iterdir() if not p.stem.startswith(\".\")]\n",
-    "names = [\"uk-v3\", \"v3\", \"with-nwp\", \"no-nwp\"]\n",
+    "    return chart, chart2\n",
     "\n",
-    "c1, c2 = error_chart(names)\n",
+    "\n",
+    "c1, c2 = error_chart(EXP_NAMES)\n",
     "display(c1)\n",
     "display(c2)"
    ]
@@ -224,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c946c02f",
+   "id": "eaebd293",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,13 +242,21 @@
     "\n",
     "scale = alt.Scale()  # clamp=True, domain=(0.01, 100))\n",
     "\n",
+    "max_ = df[\"y\"].quantile(0.99)\n",
+    "\n",
     "chart = (\n",
     "    alt.Chart(df.sample(1000))\n",
     "    .mark_circle(opacity=0.5)\n",
-    "    .encode(x=alt.X(\"y\", scale=scale), y=alt.Y(\"pred\", scale=scale), color=\"model\")\n",
+    "    .encode(\n",
+    "        x=alt.X(\"y\", scale=scale, title=\"ground truth\"),\n",
+    "        y=alt.Y(\"pred\", scale=scale, title=\"Prediction\"),\n",
+    "        color=\"model\",\n",
+    "    )\n",
     "    .properties(width=400, height=400)\n",
     ") + (\n",
-    "    alt.Chart(pd.DataFrame(dict(x=[0, 1], y=[0, 1]))).mark_line(color=\"black\").encode(x=\"x\", y=\"y\")\n",
+    "    alt.Chart(pd.DataFrame(dict(x=[0, max_], y=[0, max_])))\n",
+    "    .mark_line(color=\"black\")\n",
+    "    .encode(x=\"x\", y=\"y\")\n",
     ")\n",
     "chart"
    ]

--- a/notebooks/sample_analysis.ipynb
+++ b/notebooks/sample_analysis.ipynb
@@ -61,29 +61,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "638336cc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pwd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "2faad7cf",
    "metadata": {},
    "outputs": [],
    "source": [
     "EXPS = [\n",
-    "    \"no-nwp\",\n",
-    "    \"uk-v3\",\n",
-    "    \"with-nwp\",\n",
-    "    #     \"island-with-capacity-norm\",\n",
-    "    #     \"island-v3\",\n",
-    "]\n",
-    "EXP_CONFIG = \"uk_pv\"\n",
-    "MODELS = [f\"exp_results/{exp}/model.pkl\" for exp in EXPS]"
+    "    \"island-v3\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "389f7a42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models = [f\"exp_results/{exp}/model.pkl\" for exp in EXPS]"
    ]
   },
   {
@@ -114,18 +108,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exp_config = importlib.import_module(\".\" + EXP_CONFIG, \"psp.exp_configs\").ExpConfig()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8adc6206",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pv_ds = exp_config.get_pv_data_source()\n",
-    "nwp_ds = None"
+    "# Note that we are loading the ground truth from the first config in the case where we have many models.\n",
+    "first_exp_config = importlib.import_module(\".config\", f\"exp_results.{EXPS[0]}\").ExpConfig()\n",
+    "pv_ds = first_exp_config.get_pv_data_source()"
    ]
   },
   {
@@ -136,7 +121,8 @@
    "outputs": [],
    "source": [
     "models = {exp: load_model(model) for exp, model in zip(EXPS, MODELS)}\n",
-    "for model in models.values():\n",
+    "for name, model in models.items():\n",
+    "    exp_config = importlib.import_module(\".config\", f\"exp_results.{name}\").ExpConfig()\n",
     "    model.set_data_sources(**exp_config.get_data_source_kwargs())"
    ]
   },
@@ -232,22 +218,6 @@
     "\n",
     "    display(shap.plots.bar(explanation))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5c045ba7",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "87c55154",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/psp/scripts/eval_model.py
+++ b/psp/scripts/eval_model.py
@@ -10,13 +10,7 @@ import tqdm
 
 from psp.exp_configs.base import ExpConfigBase
 from psp.metrics import Metric, mean_absolute_error
-from psp.scripts._options import (
-    exp_config_opt,
-    exp_name_opt,
-    exp_root_opt,
-    log_level_opt,
-    num_workers_opt,
-)
+from psp.scripts._options import exp_name_opt, exp_root_opt, log_level_opt, num_workers_opt
 from psp.serialization import load_model
 from psp.training import make_data_loader
 from psp.utils.interupting import continue_on_interupt
@@ -32,7 +26,6 @@ _log = logging.getLogger(__name__)
 @click.command()
 @exp_root_opt
 @exp_name_opt
-@exp_config_opt
 @num_workers_opt
 @log_level_opt
 @click.option(
@@ -45,7 +38,7 @@ _log = logging.getLogger(__name__)
 @click.option(
     "--split", "split_name", type=str, default="test", help="split of the data to use: train | test"
 )
-def main(exp_root, exp_name, exp_config_name, num_workers, limit, split_name, log_level):
+def main(exp_root, exp_name, num_workers, limit, split_name, log_level):
     logging.basicConfig(level=getattr(logging, log_level.upper()))
 
     assert split_name in ["train", "test"]
@@ -54,7 +47,7 @@ def main(exp_root, exp_name, exp_config_name, num_workers, limit, split_name, lo
     # https://github.com/fsspec/gcsfs/issues/379
     torch.multiprocessing.set_start_method("spawn")
 
-    exp_config_module = importlib.import_module("." + exp_config_name, "psp.exp_configs")
+    exp_config_module = importlib.import_module(".config", f"{exp_root}.{exp_name}")
     exp_config: ExpConfigBase = exp_config_module.ExpConfig()
 
     data_source_kwargs = exp_config.get_data_source_kwargs()

--- a/psp/scripts/train_model.py
+++ b/psp/scripts/train_model.py
@@ -96,10 +96,10 @@ def main(
     exp_config: ExpConfigBase = exp_config_module.ExpConfig()
 
     output_dir = exp_root / exp_name
-    output_dir.mkdir(exist_ok=True)
+    output_dir.mkdir(exist_ok=False)
 
     # Also copy the config into the experiment.
-    shutil.copy(f"./psp/exp_configs/{exp_config_name}.py", output_dir)
+    shutil.copy(f"./psp/exp_configs/{exp_config_name}.py", output_dir / "config.py")
 
     # Load the model.
     model = exp_config.get_model()

--- a/psp/visualization.py
+++ b/psp/visualization.py
@@ -415,6 +415,11 @@ def plot_sample(
                 )
             if chart is None:
                 print(key)
-                print(value)
+                names = feature_names.get(key)
+                if names is not None:
+                    for name, v in zip(names, value):
+                        print(f"  {name}: {v}")
+                else:
+                    print(value)
             else:
                 display(chart)


### PR DESCRIPTION
When we train a model, we also save the experiment config that we used.

Instead of specifying (again) the config when evaluating the model (in `scripts/eval_model.py`), or in the notebook (`experiment_analysis.ipynb` and `sample_analysis.ipynb`), we load the config that was saved alongside the model.

I also fix some quirks in the notebook (like moving all the "parameters" at the top of the file!).