### PR TITLE
Only pass some of the dates when splitting dataset

### DIFF
--- a/psp/tests/test_dataset.py
+++ b/psp/tests/test_dataset.py
@@ -1,0 +1,53 @@
+import datetime as dt
+
+import pytest
+
+from psp.dataset import DatasetSplit, split_train_test
+
+# Default split dates for our PV data source fixture.
+D0 = dt.datetime(2020, 1, 1)
+D1 = dt.datetime(2020, 1, 6)
+D2 = dt.datetime(2020, 1, 7)
+D3 = dt.datetime(2020, 1, 13)
+
+
+@pytest.mark.parametrize(
+    "train_start,train_end,test_start,test_end",
+    [
+        # All of those should be equivalent and cover the most common use-cases.
+        [None, None, None, None],
+        [D0, None, None, None],
+        [None, None, None, D3],
+        [D0, None, None, D3],
+        [D0, D1, None, D3],
+        [D0, None, D2, D3],
+        [D0, D1, None, None],
+    ],
+)
+def test_split_train_test_default(pv_data_source, train_start, train_end, test_start, test_end):
+    splits = split_train_test(
+        pv_data_source,
+        train_start=train_start,
+        train_end=train_end,
+        test_start=test_start,
+        test_end=test_end,
+    )
+
+    assert splits.train == DatasetSplit(
+        start_ts=D0,
+        end_ts=D1,
+        pv_ids=["8215", "8229"],
+    )
+
+    assert splits.valid == DatasetSplit(
+        start_ts=D0,
+        end_ts=D1,
+        # We would need a more interesting data source to have non-trivial valid and test splits.
+        pv_ids=[],
+    )
+
+    assert splits.test == DatasetSplit(
+        start_ts=D2,
+        end_ts=D3,
+        pv_ids=[],
+    )


### PR DESCRIPTION
When splitting the data time-wise, we only supported specifing all dates or no dates. Now we can pass only some of the dates. In particular, we can provide the `train_start` and `test_end` dates and find good `train_end` and `test_start` dates automatically.