### PR TITLE
Blackout on data sources

### DIFF
--- a/psp/exp_configs/island.py
+++ b/psp/exp_configs/island.py
@@ -43,7 +43,12 @@ class ExpConfig(ExpConfigBase):
 
     @functools.cache
     def _get_model_config(self):
-        return PvSiteModelConfig(horizons=Horizons(duration=15, num_horizons=48 * 4), blackout=0)
+        return PvSiteModelConfig(
+            horizons=Horizons(
+                duration=15,
+                num_horizons=48 * 4,
+            )
+        )
 
     @functools.cache
     def get_model(self) -> PvSiteModel:

--- a/psp/exp_configs/test_config1.py
+++ b/psp/exp_configs/test_config1.py
@@ -29,7 +29,7 @@ class ExpConfig(ExpConfigBase):
 
     @functools.cache
     def _get_model_config(self):
-        return PvSiteModelConfig(horizons=Horizons(duration=15, num_horizons=5), blackout=0)
+        return PvSiteModelConfig(horizons=Horizons(duration=15, num_horizons=5))
 
     @functools.cache
     def get_model(self) -> PvSiteModel:

--- a/psp/exp_configs/uk_pv.py
+++ b/psp/exp_configs/uk_pv.py
@@ -174,9 +174,7 @@ class ExpConfig(ExpConfigBase):
 
     def get_model(self) -> PvSiteModel:
         return RecentHistoryModel(
-            config=PvSiteModelConfig(
-                horizons=Horizons(duration=15, num_horizons=48 * 4), blackout=0
-            ),
+            config=PvSiteModelConfig(horizons=Horizons(duration=15, num_horizons=48 * 4)),
             **self.get_data_source_kwargs(),
             regressor=SklearnRegressor(
                 num_train_samples=4096,

--- a/psp/exp_configs/yesterday.py
+++ b/psp/exp_configs/yesterday.py
@@ -24,8 +24,7 @@ class ExpConfig(ExpConfigBase):
             horizons=Horizons(
                 duration=15,
                 num_horizons=48 * 4,
-            ),
-            blackout=0,
+            )
         )
 
     @functools.cache

--- a/psp/models/base.py
+++ b/psp/models/base.py
@@ -12,10 +12,6 @@ class PvSiteModelConfig:
     """Model meta data that all models must define."""
 
     horizons: Horizons
-    # Blackout in minutes.
-    # This is a window of time before the timestamp at which we don't have access to data.
-    # This is to simulate a delay in the availability of the data, which can happen in production.
-    blackout: int
 
 
 class PvSiteModel(abc.ABC):

--- a/psp/models/recent_history.py
+++ b/psp/models/recent_history.py
@@ -162,7 +162,7 @@ class RecentHistoryModel(PvSiteModel):
         self, x: X, with_names: bool
     ) -> Features | Tuple[Features, dict[str, list[str]]]:
         features: Features = dict()
-        data_source = self._pv_data_source.without_future(x.ts, blackout=self.config.blackout)
+        data_source = self._pv_data_source.as_available_at(x.ts)
 
         # We'll look at stats for the previous few days.
         history_start = to_midnight(x.ts - timedelta(days=7))

--- a/psp/models/yesterday.py
+++ b/psp/models/yesterday.py
@@ -23,7 +23,7 @@ class YesterdayPvSiteModel(PvSiteModel):
         return Y(powers=powers)
 
     def get_features(self, x: X) -> Features:
-        data_source = self._data_source.without_future(x.ts, blackout=self.config.blackout)
+        data_source = self._data_source.as_available_at(x.ts)
         max_minutes = max(x[1] for x in self.config.horizons)
 
         yesterday = x.ts - timedelta(days=1)

--- a/psp/scripts/train_model.py
+++ b/psp/scripts/train_model.py
@@ -74,7 +74,12 @@ def _eval_model(model: PvSiteModel, dataloader: DataLoader[Sample]) -> None:
 @num_workers_opt
 @log_level_opt
 @click.option("-b", "--batch-size", default=32, show_default=True)
-@click.option("--num-test-samples", default=100, show_default=True)
+@click.option(
+    "--num-test-samples",
+    default=100,
+    show_default=True,
+    help="Number of samples to use to test on train and valid. Use 0 to skip completely.",
+)
 @click.option(
     "--force",
     is_flag=True,
@@ -161,25 +166,26 @@ def main(
     save_model(model, path)
 
     # Print the error on the train/valid sets.
-    _log.info("Error on the train set")
-    train_data_loader2 = make_data_loader(
-        **data_loader_kwargs,
-        batch_size=None,
-        split=splits.train,
-        limit=num_test_samples,
-        random_state=np.random.RandomState(SEED_TRAIN),
-    )
-    _eval_model(model, train_data_loader2)
+    if num_test_samples > 0:
+        _log.info("Error on the train set")
+        train_data_loader2 = make_data_loader(
+            **data_loader_kwargs,
+            batch_size=None,
+            split=splits.train,
+            limit=num_test_samples,
+            random_state=np.random.RandomState(SEED_TRAIN),
+        )
+        _eval_model(model, train_data_loader2)
 
-    _log.info("Error on the valid set")
-    valid_data_loader2 = make_data_loader(
-        **data_loader_kwargs,
-        batch_size=None,
-        split=splits.valid,
-        limit=num_test_samples,
-        random_state=np.random.RandomState(SEED_VALID),
-    )
-    _eval_model(model, valid_data_loader2)
+        _log.info("Error on the valid set")
+        valid_data_loader2 = make_data_loader(
+            **data_loader_kwargs,
+            batch_size=None,
+            split=splits.valid,
+            limit=num_test_samples,
+            random_state=np.random.RandomState(SEED_VALID),
+        )
+        _eval_model(model, valid_data_loader2)
 
 
 if __name__ == "__main__":

--- a/psp/tests/data/data_sources/test_pv_data_source.py
+++ b/psp/tests/data/data_sources/test_pv_data_source.py
@@ -74,7 +74,7 @@ def test_pv_data_source_ignore_future(pv_data_source):
     )
 
     # With `ignore_future`.
-    new_data_source = pv_data_source.without_future(datetime(2023, 1, 3))
+    new_data_source = pv_data_source.as_available_at(datetime(2023, 1, 3))
     assert new_data_source.min_ts() == datetime(2023, 1, 1)
     assert new_data_source.max_ts() == datetime(2023, 1, 2, 23, 59, 59)
     assert (


### PR DESCRIPTION
* Move the `blackout` setting to the data sources. It makes more sense to attach this value to the data sources, rather than the models.
* Add a way to skip the test step train script

   