### PR TITLE
pass csv to eval model

### DIFF
--- a/psp/scripts/eval_model.py
+++ b/psp/scripts/eval_model.py
@@ -107,7 +107,7 @@ def main(
     sequential: bool,
     pv_ids_one_string: str,
     step_minutes: Optional[int] = None,
-    test_dataset_file: Optional[str] = None,
+    test_dataset: Optional[str] = None,
 ):
     logging.basicConfig(level=getattr(logging, log_level.upper()))
 
@@ -200,10 +200,10 @@ def main(
         random_state=random_state,
         get_features=model.get_features,
         num_workers=num_workers,
-        shuffle=not sequential,
+        shuffle=(not sequential) and (test_dataset is None),
         step=step,
         limit=limit,
-        dataset_file=test_dataset_file,
+        dataset_file=test_dataset,
     )
 
     # Gather all errors for every samples. We'll make a DataFrame with it.

--- a/psp/scripts/eval_model.py
+++ b/psp/scripts/eval_model.py
@@ -86,6 +86,13 @@ _log = logging.getLogger(__name__)
     help="The time interval of the samples in minutes. "
     "Defaults to None and then value is taken from the configuration.",
 )
+@click.option(
+    "--test-dataset",
+    type=str,
+    default=None,
+    help="The csv file for the test dataset to use. Defaults to None. "
+    "The csv must have pv_id and timestamp columns.",
+)
 def main(
     exp_root,
     exp_name,
@@ -100,6 +107,7 @@ def main(
     sequential: bool,
     pv_ids_one_string: str,
     step_minutes: Optional[int] = None,
+    test_dataset_file: Optional[str] = None,
 ):
     logging.basicConfig(level=getattr(logging, log_level.upper()))
 
@@ -195,6 +203,7 @@ def main(
         shuffle=not sequential,
         step=step,
         limit=limit,
+        dataset_file=test_dataset_file,
     )
 
     # Gather all errors for every samples. We'll make a DataFrame with it.

--- a/psp/tests/test_training.py
+++ b/psp/tests/test_training.py
@@ -44,11 +44,9 @@ def test_pvx_datapipe_dataset(pv_data_source):
             dataset_file=f.name,
         )
 
-        pvx = iter(pvx)
-        x = next(pvx)
+        x, y = [x for x in iter(pvx)]
         assert x.pv_id == "0"
         assert x.ts == datetime(2020, 1, 1)
 
-        x = next(pvx)
-        assert x.pv_id == "1"
-        assert x.ts == datetime(2020, 1, 2)
+        assert y.pv_id == "1"
+        assert y.ts == datetime(2020, 1, 2)

--- a/psp/tests/test_training.py
+++ b/psp/tests/test_training.py
@@ -1,0 +1,54 @@
+import tempfile
+from datetime import datetime
+
+import pandas as pd
+
+from psp.training import PvXDataPipe
+from psp.typings import Horizons
+
+
+def test_pvx_datapipe(pv_data_source):
+
+    pvx = PvXDataPipe(
+        data_source=pv_data_source,
+        horizons=Horizons(duration=15, num_horizons=48 * 4),
+        pv_ids=["0", "1", "2"],
+        start_ts=datetime(2020, 1, 1),
+        end_ts=datetime(2021, 1, 1),
+        step=15,
+    )
+
+    x = next(iter(pvx))
+    assert x.pv_id in ["0", "1", "2"]
+    assert x.ts >= datetime(2020, 1, 1)
+    assert x.ts <= datetime(2021, 1, 1)
+
+
+def test_pvx_datapipe_dataset(pv_data_source):
+
+    # create a temp csv file with columns ['pv_id', 'timestamp']
+    # with 2 rows of random data
+    with tempfile.NamedTemporaryFile() as f:
+        df = pd.DataFrame(
+            {"pv_id": ["0", "1"], "timestamp": [datetime(2020, 1, 1), datetime(2020, 1, 2)]}
+        )
+        df.to_csv(f.name, index=False)
+
+        pvx = PvXDataPipe(
+            data_source=pv_data_source,
+            horizons=Horizons(duration=15, num_horizons=48 * 4),
+            pv_ids=["0", "1", "2"],
+            start_ts=datetime(2020, 1, 1),
+            end_ts=datetime(2021, 1, 1),
+            step=15,
+            dataset_file=f.name,
+        )
+
+        pvx = iter(pvx)
+        x = next(pvx)
+        assert x.pv_id == "0"
+        assert x.ts == datetime(2020, 1, 1)
+
+        x = next(pvx)
+        assert x.pv_id == "1"
+        assert x.ts == datetime(2020, 1, 2)

--- a/psp/training.py
+++ b/psp/training.py
@@ -56,14 +56,12 @@ class PvXDataPipe(IterDataPipe[X]):
         assert self._end_ts > self._start_ts
 
         if self._dataset_file is not None:
-            self.dataset = pd.read_csv(self._dataset_file)
-        else:
-            self.dataset = None
+            self._dataset = pd.read_csv(self._dataset_file)
 
     def __iter__(self) -> Iterator[X]:
         step = dt.timedelta(minutes=self._step)
 
-        if self.dataset is None:
+        if self._dataset_file is None:
             for pv_id in self._pv_ids:
                 ts = self._start_ts
                 minute = ts.minute
@@ -73,7 +71,7 @@ class PvXDataPipe(IterDataPipe[X]):
                     yield x
                     ts = ts + step
         else:
-            for index, row in self.dataset.iterrows():
+            for index, row in self._dataset.iterrows():
                 pv_id = str(row["pv_id"])
                 ts = pd.Timestamp(row["timestamp"])
                 ts = ts.replace(second=0, microsecond=0)
@@ -203,6 +201,7 @@ def make_data_loader(
     shuffle: bool = False,
     step: int = 1,
     limit: int | None = None,
+    dataset_file: str | None = None,
 ) -> "DataLoader[Sample]":
     ...
 
@@ -222,6 +221,7 @@ def make_data_loader(
     shuffle: bool = False,
     step: int = 1,
     limit: int | None = None,
+    dataset_file: str | None = None,
 ) -> "DataLoader[Batch]":
     ...
 

--- a/psp/training.py
+++ b/psp/training.py
@@ -31,6 +31,7 @@ class PvXDataPipe(IterDataPipe[X]):
         start_ts: Timestamp | None = None,
         end_ts: Timestamp | None = None,
         step: int = 15,
+        dataset_file: str | None = None,
     ):
         """
         Arguments:
@@ -39,6 +40,8 @@ class PvXDataPipe(IterDataPipe[X]):
             start_ts: If provided, wll only pick dates after this date.
             end_ts: If provided, wll only pick dates before this date.
             step: Step used to make samples in time (in minutes).
+            dataset_file: If provided, will only pick from those pv_ids.
+                This has columns of pv_id and timestamp
         """
         self._data_source = data_source
         self._horizons = horizons
@@ -46,22 +49,36 @@ class PvXDataPipe(IterDataPipe[X]):
         self._start_ts = start_ts or self._data_source.min_ts()
         self._end_ts = end_ts or self._data_source.max_ts()
         self._step = step
+        self._dataset_file = dataset_file
 
         # Sanity checks.
         assert len(self._pv_ids) > 0
         assert self._end_ts > self._start_ts
 
+        if self._dataset_file is not None:
+            self.dataset = pd.read_csv(self._dataset_file)
+        else:
+            self.dataset = None
+
     def __iter__(self) -> Iterator[X]:
         step = dt.timedelta(minutes=self._step)
 
-        for pv_id in self._pv_ids:
-            ts = self._start_ts
-            minute = ts.minute
-            ts = ts.replace(minute=round_to(minute, self._step), second=0, microsecond=0)
-            while ts < self._end_ts:
+        if self.dataset is None:
+            for pv_id in self._pv_ids:
+                ts = self._start_ts
+                minute = ts.minute
+                ts = ts.replace(minute=round_to(minute, self._step), second=0, microsecond=0)
+                while ts < self._end_ts:
+                    x = X(pv_id=pv_id, ts=ts)
+                    yield x
+                    ts = ts + step
+        else:
+            for index, row in self.dataset.iterrows():
+                pv_id = str(row["pv_id"])
+                ts = pd.Timestamp(row["timestamp"])
+                ts = ts.replace(second=0, microsecond=0)
                 x = X(pv_id=pv_id, ts=ts)
                 yield x
-                ts = ts + step
 
 
 # We inherit from PvSamplesGenerator to save some code even though it's not super sound.
@@ -223,6 +240,7 @@ def make_data_loader(
     shuffle: bool = False,
     step: int = 1,
     limit: int | None = None,
+    dataset_file: str | None = None,
 ) -> "DataLoader[Sample] | DataLoader[Batch]":
     """
     Arguments:
@@ -230,6 +248,8 @@ def make_data_loader(
         batch_size: Batch size. None means no batching.
         step: Step in minutes for the timestamps.
         limit: return only this number of samples.
+        dataset_file: is a csv file that has the column pv_id and timestamp.
+            These are used to generate the dataset.
     """
     pvx_datapipe: PvXDataPipe
     if shuffle:
@@ -251,6 +271,7 @@ def make_data_loader(
             start_ts=start_ts,
             end_ts=end_ts,
             step=step,
+            dataset_file=dataset_file,
         )
 
     # This has to be as early as possible to be efficient!


### PR DESCRIPTION
# Pull Request

## Description

The aim is to be able to pass a csv to the eval_model script. 

This means we can really compare `apples` and `apples` to `apples` and `bananas`

## How Has This Been Tested?

- CI tests
- added a test
- run eval script on donatello

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
