### PR TITLE
Sort satellite data by time and remove use of the word sat

### DIFF
--- a/psp/data_sources/nwp.py
+++ b/psp/data_sources/nwp.py
@@ -133,6 +133,9 @@ class NwpDataSource:
         if self._variables is not None:
             data = data.sel(variable=self._variables)
 
+        # Sort data in time
+        data = data.sortby(_TIME)
+
         return data
 
     def list_variables(self) -> list[str]:

--- a/psp/models/recent_history.py
+++ b/psp/models/recent_history.py
@@ -204,7 +204,7 @@ class RecentHistoryModel(PvSiteModel):
         self.set_data_sources(
             pv_data_source=pv_data_source,
             nwp_data_sources=nwp_data_sources,
-            sat_data_sources=satellite_data_sources,
+            satellite_data_sources=satellite_data_sources,
         )
 
         # We bump this when we make backward-incompatible changes in the code, to support old
@@ -218,7 +218,7 @@ class RecentHistoryModel(PvSiteModel):
         *,
         pv_data_source: PvDataSource,
         nwp_data_sources: dict[str, NwpDataSource] | None = None,
-        sat_data_sources: dict[str, SatelliteDataSource] | None = None,
+        satellite_data_sources: dict[str, SatelliteDataSource] | None = None,
     ):
         """Set the data sources.
 
@@ -226,7 +226,7 @@ class RecentHistoryModel(PvSiteModel):
         """
         self._pv_data_source = pv_data_source
         self._nwp_data_sources = nwp_data_sources
-        self._satellite_data_sources = sat_data_sources
+        self._satellite_data_sources = satellite_data_sources
 
         # This ensures the nwp fixture passed for the test is a dictionary
         if isinstance(self._nwp_data_sources, dict) or self._nwp_data_sources is None:
@@ -238,7 +238,7 @@ class RecentHistoryModel(PvSiteModel):
         if (self._satellite_data_sources is not None) and (
             not isinstance(self._satellite_data_sources, dict)
         ):
-            self._satellite_data_sources = dict(sat_data_source=self._satellite_data_sources)
+            self._satellite_data_sources = dict(satellite_data_source=self._satellite_data_sources)
 
         # set this attribute so it works for older models
         if not hasattr(self, "_satellite_patch_size"):

--- a/psp/tests/models/test_load_models.py
+++ b/psp/tests/models/test_load_models.py
@@ -25,12 +25,12 @@ def test_old_models_sanity_check():
     assert sorted(models) == sorted(EXPECTED_OUTPUT)
 
 
-def _test_model(model_path, expected, pv_data_source, nwp_data_sources, sat_data_source=None):
+def _test_model(model_path, expected, pv_data_source, nwp_data_sources, satellite_data_source=None):
     model = load_model(model_path)
     model.set_data_sources(
         pv_data_source=pv_data_source,
         nwp_data_sources=nwp_data_sources,
-        sat_data_sources=sat_data_source,
+        satellite_data_sources=satellite_data_source,
     )
 
     pv_id = pv_data_source.list_pv_ids()[0]


### PR DESCRIPTION
# Pull Request

An "index must be monotonic" error occurred when the satellite data pulled from Google was processed. This has been fixed by sorting the dataset by time in the data preparation stage.

Additionally, when running evaluation, sat_data_sources was being passed when satellite_data_sources was expected. This has been resolved and to avoid confusion, all uses of sat_data_sources has been changed to satellite_data_sources.

Tests have been updated to reflect the changes. 